### PR TITLE
Ring colors are set with 24 bytes, 3/ color

### DIFF
--- a/Project-Aurora/Project-Aurora/Devices/NZXT/NZXTDevice.cs
+++ b/Project-Aurora/Project-Aurora/Devices/NZXT/NZXTDevice.cs
@@ -134,7 +134,7 @@ namespace Aurora.Devices.NZXT
         public bool UpdateDevice(Dictionary<DeviceKeys, Color> keycolors, DoWorkEventArgs e, bool forced = false)
         {
             var huepluscolors = new List<byte>(120);
-            var krakenringcolors = new List<byte>(8);
+            var krakenringcolors = new List<byte>(24);
 
             if (e.Cancel) return false;
 


### PR DESCRIPTION
<!-- Thank you for helping Aurora grow as a community project! We appreciate your help, and would love to see more additions to our code from you! :)  -->

<!-- 
============================
A checklist before submitting a Pull Request
============================
1. Ensure that your code follows the CamelCase naming convention. ( https://en.wikipedia.org/wiki/Camel_case )
2. Ensure that you are making a pull request for the dev branch, and not master branch. ( Master branch commits will not be accepted )
3. Fill out the form below with as much information as you can. Feel free to add more comments if you need to.
 -->

**List any issues that this PR fixes:** fixes # , etc...
N/A, haven't created an issue for it

**This pull request proposes the following changes:**
<!-- List changes that this RP includes -->
- The list containing the color bytes for the kraken ring colors would need to be of length 24: 3 bytes/ color.


